### PR TITLE
Fixes error in call to cvHaarDetectObjects

### DIFF
--- a/src/AI/CV/OpenCV/HOpenCV_wrap.c
+++ b/src/AI/CV/OpenCV/HOpenCV_wrap.c
@@ -141,6 +141,6 @@ CvSeq *c_cvHaarDetectObjects( const CvArr* image,
                               int min_neighbors , int flags,
                               int width, int height)
 {
-    return cvHaarDetectObjects(image, cascade, storage, scale_factor, min_neighbors, flags, cvSize(width, height), cvSize(0, 0));
+    return cvHaarDetectObjects(image, cascade, storage, scale_factor, min_neighbors, flags, cvSize(width, height));
 }
 


### PR DESCRIPTION
I was testing the new version of HOpenCV and I got:

```
Building HOpenCV-0.1.2.2...
[1 of 4] Compiling AI.CV.OpenCV.CxCore ( dist/build/AI/CV/OpenCV/CxCore.hs, dist/build/AI/CV/OpenCV /CxCore.o )
[2 of 4] Compiling AI.CV.OpenCV.HighGui ( dist/build/AI/CV/OpenCV/HighGui.hs, dist/build/AI/CV/OpenCV/HighGui.o )
[3 of 4] Compiling AI.CV.OpenCV.Types ( src/AI/CV/OpenCV/Types.hs, dist/build/AI/CV/OpenCV/Types.o )
[4 of 4] Compiling AI.CV.OpenCV.CV  ( dist/build/AI/CV/OpenCV/CV.hs, dist/build/AI/CV/OpenCV/CV.o )
src/AI/CV/OpenCV/HOpenCV_wrap.c: In function ‘c_cvHaarDetectObjects’:

src/AI/CV/OpenCV/HOpenCV_wrap.c:144:5:
    error: too many arguments to function ‘cvHaarDetectObjects’

/usr/include/opencv/cv.h:1239:15:  note: declared here
```

This commit adds what I guess you inteded to write instead. Feel free to ignore it if that was not the case.
