### PR TITLE
releaseMemStorage no longer causes a segfault.

### DIFF
--- a/src/AI/CV/OpenCV/CxCore.hsc
+++ b/src/AI/CV/OpenCV/CxCore.hsc
@@ -132,7 +132,7 @@ numToDepth x = lookup x depthsLookupList
 foreign import ccall unsafe "cxcore.h cvCreateMemStorage"
   c_cvCreateMemStorage :: CInt -> IO (Ptr Priv_CvMemStorage)
 
-foreign import ccall unsafe "core_c.h &cvReleaseMemStorage"
+foreign import ccall unsafe "HOpenCV_wrap.h &release_mem_storage"
   releaseMemStorage :: FunPtr (Ptr a -> IO ())
 
 createMemStorage :: Int -> IO MemStorage

--- a/src/AI/CV/OpenCV/HOpenCV_wrap.c
+++ b/src/AI/CV/OpenCV/HOpenCV_wrap.c
@@ -107,13 +107,11 @@ void dilate(const CvArr *src, CvArr *dest, int iterations)
 }
 
 /**********************************************************/
-/*
 void release_mem_storage(CvMemStorage *mem_store)
 {
     CvMemStorage *temp = mem_store;
     cvReleaseMemStorage(&temp);
 }
-*/
 
 void cv_free(void *obj)
 {


### PR DESCRIPTION
I was getting a segfault when `releaseMemStorage` was called. Simply wrapping it like this, using the previously commented out code, seems to work. Is there something that I'm missing here?
